### PR TITLE
Fix PVC creation if SC is not specified

### DIFF
--- a/cmd/create_pvc.go
+++ b/cmd/create_pvc.go
@@ -96,7 +96,7 @@ func (o *CreatePVCOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 }
 
 func (o *CreatePVCOptions) createPVCObject() *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
+	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      o.Name,
 			Namespace: o.Namespace,
@@ -107,12 +107,17 @@ func (o *CreatePVCOptions) createPVCObject() *corev1.PersistentVolumeClaim {
 					"storage": resource.MustParse(fmt.Sprintf("%sGi", o.Size)),
 				},
 			},
-			StorageClassName: &o.StorageClass,
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteOnce,
 			},
 		},
 	}
+
+	if o.StorageClass != "" {
+		pvc.Spec.StorageClassName = &o.StorageClass
+	}
+
+	return pvc
 }
 
 func (o *CreatePVCOptions) Run() error {


### PR DESCRIPTION
If SC was not configured in CLI `kreate` the PVC resource that got created has SC set to empty string `""` which resulted into the problem and the volume was not provisioned. 

```
Events:
  Type    Reason         Age                From                         Message
  ----    ------         ----               ----                         -------
  Normal  FailedBinding  13s (x2 over 28s)  persistentvolume-controller  no persistent volumes available for this claim and no storage class is set
```

This commit fixes that by making sure that if the sc is not configured we don't sc which would result into defalt SC being used in the PVC.